### PR TITLE
Update mathjs name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add a dependency in your module.json:
 ```json
   "dependencies": [
     {
-      "name": "Math.js",
+      "name": "_mathjs",
       "manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/mathjs-lib/master/module.json"
     }
   ]


### PR DESCRIPTION
Apparently I screwed up the "mathjs" name in the module.json. Sorry!